### PR TITLE
FIX: YourBible Bible Verse Notes Format

### DIFF
--- a/React Frontend/src/components/yourbible_components/YourBibleLessonEntry.tsx
+++ b/React Frontend/src/components/yourbible_components/YourBibleLessonEntry.tsx
@@ -3,6 +3,7 @@ import YourBibleLessonModal from "./modals/YourBibleLessonModal";
 import axios from "../../api/axios";
 import useAuth from "../../hooks/useAuth";
 import { AuthProp } from "../../props/CommonProps";
+import { hasNewLine, getSubStrings } from "../../helper/yourbible_helper/YourBibleHelperFunctions";
 import { BibleLesson_Context, BibleLessonContextProp } from "../../views/YourBibleLessonView";
 
 interface YourBibleLessonEntryProp {
@@ -64,7 +65,13 @@ const YourBibleLessonEntry = ({ id, index,
                     </div>
                     <div className="collapse-content">
                          <ul className="list-disc list-inside">
-                            <li>{bibleVerseNotes}</li>
+                            { hasNewLine(bibleVerseNotes) === true ? 
+                            getSubStrings(bibleVerseNotes).map((bibleVerse: string) => 
+                                <li>{bibleVerse}</li>
+                            )
+                            :
+                            <li>{bibleVerseNotes}</li> }
+                            
                          </ul>
                     </div>
                 </div>

--- a/React Frontend/src/components/yourbible_components/YourBibleLessonEntry.tsx
+++ b/React Frontend/src/components/yourbible_components/YourBibleLessonEntry.tsx
@@ -63,7 +63,9 @@ const YourBibleLessonEntry = ({ id, index,
                         {bibleVerse}
                     </div>
                     <div className="collapse-content">
-                        {bibleVerseNotes}
+                         <ul className="list-disc list-inside">
+                            <li>{bibleVerseNotes}</li>
+                         </ul>
                     </div>
                 </div>
                 <div className="flex flex-col ml-5">

--- a/React Frontend/src/components/yourbible_components/modals/YourBibleEntryModal.tsx
+++ b/React Frontend/src/components/yourbible_components/modals/YourBibleEntryModal.tsx
@@ -19,6 +19,7 @@ const YourBibleEntryModal = ({ mode, originalTitle, bibleStudyId,
     const { toggleSubmitted } = useContext<ContextProp>(YourBible_Context);
     const CREATE_BIBLE_URL = `yourBible/createBibleStudy?userId=${auth.id}`;
     const UPDATE_BIBLE_URL = `yourBible/updateBibleStudy?bibleStudyId=${bibleStudyId}`;
+    
     // If mode is create, set title to empty string, otherwise set it to the original title
     const [title, setTitle] = useState<string>(originalTitle || "");
     

--- a/React Frontend/src/helper/yourbible_helper/YourBibleHelperFunctions.ts
+++ b/React Frontend/src/helper/yourbible_helper/YourBibleHelperFunctions.ts
@@ -1,0 +1,7 @@
+export const hasNewLine = (str: string): boolean => {
+    return /\r|\n/.test(str);
+}
+
+export const getSubStrings = (str: string): string[] => {
+    return str.split(/\r|\n/);
+}


### PR DESCRIPTION
## Description
Ensures that when a user separates Bible verse notes by a new line, all sub strings are separated by bullet points
If a user only has 1 line of notes, they are still on a bullet point

These changes are needed to increase readability of Bible verse notes and encourage compact notes


## Testing
**Steps to test this PR:**
1. Create a Bible message
2. Create a Bible verse note
3. Either submit the Bible verse note with only 1 line of text or submit the Bible verse note with more than 1 line of text
